### PR TITLE
Integrate run_step and summarize actions into VirtualLab

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,10 @@ virtuallab/
 | `add_data`       | 创建 `Data` 节点，记录数据引用元信息 | 支持记录来源、格式、引用指针 |
 | `link`           | 在任意节点间创建一条有向边 | `source`, `target`, `type`, `attributes` |
 | `query`          | 基于 `QueryService` 查询图谱 | `kind` ∈ {`by_type`, `timeline`, `neighbors`} |
+| `run_step`       | 通过 `StepRunner` 调用执行适配器并回写步骤结果 | `step_id`, `tool`（可选，默认读取节点）, `payload` |
+| `summarize`      | 使用 `SummaryService` 调用外部 LLM 生成总结，可选写回图谱 | `text`, `style`（可选）, `target_id`（可选） |
 
-以下动作已注册占位符，当前会返回「未实现」的提示：`run_step`、`summarize`、`record_note`、`auto_link`、`export_graph`、`snapshot`、`rollback`。
+以下动作已注册占位符，当前会返回「未实现」的提示：`record_note`、`auto_link`、`export_graph`、`snapshot`、`rollback`。
 
 ## 图谱模型与操作
 
@@ -95,7 +97,7 @@ virtuallab/
 ## 执行、总结与持久化扩展点
 
 - `StepRunner` 维护执行适配器注册表，`run(tool, step_id, payload)` 会分发到具体适配器，实现按工具类型的灵活调度。
-- `SummaryService` 抽象总结能力，调用外部适配器产出结构化结果。
+- `SummaryService` 抽象总结能力，调用外部适配器产出结构化结果；默认接入 OpenAI 兼容客户端，缺省时会降级为回声总结，方便本地开发与测试。
 - `GraphExporter` 与 `SnapshotManager` 分别负责图谱导出与快照回滚，当前实现为占位，可在后续迭代中接入持久化。
 
 ## 事件与可观测性
@@ -106,9 +108,9 @@ virtuallab/
 
 短期方向包括：
 
-1. 打通 `run_step`、`summarize` 等动作，将执行器与总结服务纳入主流程。
-2. 实现自动连边规则（时序、依赖、因果等）。
-3. 完善导出、快照回滚与外部持久化集成。
-4. 增加端到端示例与测试用例，覆盖典型交互路径。
+1. 实现自动连边规则（时序、依赖、因果等）。
+2. 完善导出、快照回滚与外部持久化集成。
+3. 增加端到端示例与测试用例，覆盖典型交互路径。
+4. 提供更多执行与总结适配器样例，支持异步与流式场景。
 
 当前代码骨架为后续迭代预留了清晰的模块边界，可按需替换或扩展各层能力。

--- a/virtuallab/api.py
+++ b/virtuallab/api.py
@@ -11,6 +11,7 @@ from virtuallab.graph.query import QueryService
 from virtuallab.obs.events import EventBus
 from virtuallab.router import ActionRouter
 from virtuallab.exec.runner import StepRunner
+from virtuallab.knowledge import OpenAILLMSummarizerAdapter, SummaryService
 
 
 @dataclass
@@ -21,9 +22,21 @@ class VirtualLabApp:
     event_bus: EventBus = field(default_factory=EventBus)
     router: ActionRouter = field(default_factory=ActionRouter)
     step_runner: StepRunner = field(default_factory=StepRunner)
+    summary_service: SummaryService | None = None
 
     def __post_init__(self) -> None:
+        if self.summary_service is None:
+            try:
+                adapter = OpenAILLMSummarizerAdapter()
+            except (ModuleNotFoundError, ImportError):  # pragma: no cover - optional deps
+                class _EchoSummarizer:
+                    def summarize(self, *, text: str, style: str | None = None) -> str:
+                        return text if style is None else f"[{style}] {text}"
+
+                adapter = _EchoSummarizer()
+            self.summary_service = SummaryService(adapter=adapter)
         self._register_default_actions()
+        self._register_default_step_adapters()
 
     def handle(self, payload: dict) -> dict:
         """Dispatch an API payload and return a canonical response."""
@@ -49,9 +62,9 @@ class VirtualLabApp:
         self.router.register("add_data", self._handle_add_data)
         self.router.register("link", self._handle_link)
         self.router.register("query", self._handle_query)
+        self.router.register("run_step", self._handle_run_step)
+        self.router.register("summarize", self._handle_summarize)
         for action in (
-            "run_step",
-            "summarize",
             "record_note",
             "auto_link",
             "export_graph",
@@ -59,6 +72,19 @@ class VirtualLabApp:
             "rollback",
         ):
             self.router.register(action, self._not_implemented_action(action))
+
+    def _register_default_step_adapters(self) -> None:
+        if "engineer" in self.step_runner.adapters:
+            return
+        try:
+            from virtuallab.exec.adapters.engineer import EngineerAdapter
+
+            self.step_runner.register_adapter("engineer", EngineerAdapter())
+        except ModuleNotFoundError:  # pragma: no cover - optional dependency
+            # The Engineer adapter depends on the external ``smolagents`` package.
+            # When it is unavailable we silently skip registration so that callers
+            # can supply their own lightweight adapters during testing.
+            return
 
     def _not_implemented_action(self, action: str):
         def _handler(_: dict) -> dict:
@@ -213,6 +239,88 @@ class VirtualLabApp:
         else:
             raise ValueError(f"Unsupported query kind: {kind}")
         return {"result": {"items": results}, "graph_delta": None}
+
+    def _handle_run_step(self, params: dict) -> dict:
+        step_id = params.get("step_id")
+        if not step_id:
+            raise KeyError("'step_id' is required")
+        step = self.graph_store.get_node(step_id)
+        if step is None or step.type is not NodeType.STEP:
+            raise KeyError(f"Step '{step_id}' does not exist")
+
+        tool = params.get("tool") or step.attributes.get("tool")
+        if not tool:
+            raise KeyError("A 'tool' is required to execute the step")
+
+        payload = params.get("payload") or {}
+        execution_details = self.step_runner.run(tool=tool, step_id=step_id, payload=payload)
+        execution_record = dict(execution_details)
+        execution_record.setdefault("step_id", step_id)
+        execution_record.setdefault("tool", tool)
+
+        run_id = execution_record.get("run_id") or params.get("run_id")
+        if not run_id:
+            run_id = new_id("run")
+            execution_record["run_id"] = run_id
+
+        status = execution_record.get("status") or "completed"
+        timestamp = utc_now()
+
+        updates: dict[str, object] = {
+            "status": status,
+            "run_id": run_id,
+            "updated_at": timestamp,
+            "executed_at": timestamp,
+            "last_run_tool": tool,
+        }
+
+        if "output" in execution_record:
+            updates["last_run_output"] = execution_record["output"]
+        if "error" in execution_record:
+            updates["last_run_error"] = execution_record["error"]
+        if "metrics" in execution_record:
+            updates["last_run_metrics"] = execution_record["metrics"]
+
+        updated_node = NodeSpec(id=step.id, type=step.type, attributes=updates)
+        delta = GraphDelta(updated_nodes=[updated_node])
+        self.graph_store.apply_delta(delta)
+
+        result_payload = {
+            "step_id": step_id,
+            "run_id": run_id,
+            "status": status,
+            "output": execution_record.get("output"),
+            "details": execution_record,
+        }
+        return {"result": result_payload, "graph_delta": delta}
+
+    def _handle_summarize(self, params: dict) -> dict:
+        if self.summary_service is None:
+            raise RuntimeError("Summary service is not configured")
+        text = params.get("text")
+        if not text:
+            raise KeyError("'text' is required")
+        style = params.get("style")
+        summary_result = self.summary_service.summarize(text=text, style=style)
+
+        target_id = params.get("target_id")
+        delta: Optional[GraphDelta]
+        if target_id:
+            node = self.graph_store.get_node(target_id)
+            if node is None:
+                raise KeyError(f"Node '{target_id}' does not exist")
+            updates = {
+                "summary": summary_result["summary"],
+                "summary_style": summary_result["style"],
+                "updated_at": utc_now(),
+            }
+            updated_node = NodeSpec(id=node.id, type=node.type, attributes=updates)
+            delta = GraphDelta(updated_nodes=[updated_node])
+            self.graph_store.apply_delta(delta)
+        else:
+            delta = None
+
+        return {"result": summary_result, "graph_delta": delta}
 
     def _serialize_graph_delta(self, delta: Optional[GraphDelta]) -> dict:
         if delta is None:

--- a/virtuallab/knowledge/__init__.py
+++ b/virtuallab/knowledge/__init__.py
@@ -1,5 +1,5 @@
 """Knowledge management utilities for VirtualLab."""
 
-from .summarize import SummaryService
+from .summarize import OpenAILLMSummarizerAdapter, SummaryService
 
-__all__ = ["SummaryService"]
+__all__ = ["SummaryService", "OpenAILLMSummarizerAdapter"]

--- a/virtuallab/knowledge/summarize.py
+++ b/virtuallab/knowledge/summarize.py
@@ -1,8 +1,9 @@
 """Summarization utilities for VirtualLab."""
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Protocol
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any, AsyncIterator, Awaitable, Callable, Protocol
 
 
 class SummarizerAdapter(Protocol):
@@ -10,6 +11,83 @@ class SummarizerAdapter(Protocol):
 
     def summarize(self, *, text: str, style: str | None = None) -> str:
         """Summarize ``text`` according to ``style``."""
+
+
+CompletionFn = Callable[..., Awaitable[str | AsyncIterator[str]]]
+
+
+def _run_sync(coro: Awaitable[str]) -> str:
+    """Execute ``coro`` synchronously, creating an event loop if required."""
+
+    try:
+        return asyncio.run(coro)
+    except RuntimeError as exc:  # pragma: no cover - running loop edge case
+        if "asyncio.run() cannot be called" in str(exc):
+            raise RuntimeError(
+                "OpenAILLMSummarizerAdapter cannot execute because an event loop is already running. "
+                "Provide a pre-executed summary instead."
+            ) from exc
+        raise
+
+
+async def _ensure_text(result: str | AsyncIterator[str]) -> str:
+    """Normalise OpenAI streaming responses to a plain string."""
+
+    if isinstance(result, str):
+        return result
+
+    chunks: list[str] = []
+    async for chunk in result:
+        chunks.append(chunk)
+    return "".join(chunks)
+
+
+@dataclass
+class OpenAILLMSummarizerAdapter:
+    """Adapter that delegates summarisation to an OpenAI-compatible model."""
+
+    completion_func: CompletionFn | None = None
+    system_prompt: str = (
+        "You are an expert research assistant who produces concise, structured summaries."
+    )
+    completion_kwargs: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.completion_func is None:
+            from virtuallab.exec.adapters.openai_model import gpt_4o_mini_complete
+
+            self.completion_func = gpt_4o_mini_complete
+
+    def summarize(self, *, text: str, style: str | None = None) -> str:
+        prompt = self._build_prompt(text=text, style=style)
+
+        async def _invoke() -> str:
+            if self.completion_func is None:  # pragma: no cover - defensive guard
+                raise RuntimeError("LLM completion function is not configured")
+            raw_result = await self.completion_func(
+                prompt,
+                system_prompt=self.system_prompt,
+                **self.completion_kwargs,
+            )
+            return await _ensure_text(raw_result)
+
+        return _run_sync(_invoke())
+
+    def _build_prompt(self, *, text: str, style: str | None) -> str:
+        instructions = [
+            "Summarize the following content for archival in the VirtualLab knowledge base.",
+        ]
+        if style:
+            instructions.append(f"Format the summary using the '{style}' style when possible.")
+        instructions.extend(
+            [
+                "Focus on the key findings, decisions, and recommended next steps.",
+                "Text:",
+                text,
+                "Summary:",
+            ]
+        )
+        return "\n".join(instructions)
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- document the now-implemented `run_step` and `summarize` actions in the README action table
- clarify the default `SummaryService` behaviour and refresh the short-term roadmap items

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da2d3690488331b8983c774ead14a2