### PR TITLE
Fix timeline query scope filtering

### DIFF
--- a/tests/test_virtual_lab_app.py
+++ b/tests/test_virtual_lab_app.py
@@ -285,6 +285,25 @@ def test_timeline_query_orders_by_timestamp(app: VirtualLabApp) -> None:
     assert [item["id"] for item in items] == [plan_id, subtask_id]
 
 
+def test_timeline_scope_includes_plan_node(app: VirtualLabApp) -> None:
+    plan_id = _create_plan(app)
+    _add_subtask(app, plan_id)
+
+    response = app.handle(
+        {
+            "action": "query",
+            "params": {
+                "kind": "timeline",
+                "scope": {"plan_id": plan_id},
+                "include": [NodeType.PLAN.value, NodeType.SUBTASK.value],
+            },
+        }
+    )
+
+    items = response["result"]["items"]
+    assert items[0]["id"] == plan_id
+
+
 def test_handle_requires_action_key(app: VirtualLabApp) -> None:
     with pytest.raises(KeyError, match="action"):
         app.handle({})

--- a/virtuallab/graph/query.py
+++ b/virtuallab/graph/query.py
@@ -59,7 +59,7 @@ class QueryService:
                 continue
             if scope:
                 plan_id = scope.get("plan_id")
-                if plan_id and data.get("plan_id") != plan_id and data.get("id") != plan_id:
+                if plan_id and data.get("plan_id") != plan_id and node_id != plan_id:
                     continue
             timestamp = data.get("executed_at") or data.get("created_at")
             nodes.append((timestamp, {"id": node_id, **data}))


### PR DESCRIPTION
## Summary
- ensure timeline queries scoped to a plan retain the plan node itself
- add a regression test that exercises the scoped timeline behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da392ee79c8331b3210eb1733120b0