### PR TITLE
Update requirements for OpenAI adapter dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
+httpx>=0.27
 networkx>=3.5
+numpy>=1.26
+openai>=1.51
+tenacity>=8.2
 


### PR DESCRIPTION
## Summary
- add missing third-party libraries used by the OpenAI adapter to requirements.txt

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da3e6305cc8331a689f9d50093c366