### PR TITLE
Load environment configuration from .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,20 @@
+# Default environment configuration for virtuallab
+# Update these values locally to match your runtime setup.
+
+# Engineer adapter configuration
+LLM_MODEL=
+LLM_MODEL_URL=
+LLM_MODEL_API_KEY=
+
+# OpenAI adapter configuration
+OPENAI_API_KEY=
+OPENAI_API_URL=
+OPENAI_API_MODEL=
+VERBOSE=false
+http_proxy_port=
+
+# Embedding service configuration
+EMBEDDING_BINDING_API_KEY=
+EMBEDDING_BINDING_URL=
+EMBEDDING_MODEL=
+EMBEDDING_DIM=

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 networkx>=3.5
+python-dotenv>=1.0.1
 

--- a/virtuallab/config.py
+++ b/virtuallab/config.py
@@ -1,0 +1,54 @@
+"""Configuration helpers for loading environment variables.
+
+This module ensures that variables defined in a project-level ``.env`` file
+are loaded before attempting to access them.  Consumers should rely on the
+``get_env`` helper instead of using :func:`os.getenv` directly so that the
+configuration is loaded in a single, well-defined place.
+"""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional
+
+from dotenv import load_dotenv
+
+
+@lru_cache(maxsize=1)
+def _load_environment() -> None:
+    """Load environment variables from the project's ``.env`` file.
+
+    The loader first attempts to read ``.env`` from the repository root.  If the
+    file does not exist we still call :func:`load_dotenv` to allow the default
+    discovery mechanism to run (e.g., for users who store the file elsewhere).
+    Subsequent calls are cached so the file is only read once per process.
+    """
+
+    project_root = Path(__file__).resolve().parents[1]
+    env_path = project_root / ".env"
+
+    if env_path.exists():
+        load_dotenv(env_path, override=False)
+    else:
+        load_dotenv(override=False)
+
+
+def get_env(key: str, default: Optional[str] = None) -> Optional[str]:
+    """Return the value for ``key`` from the environment.
+
+    Parameters
+    ----------
+    key:
+        The name of the environment variable to look up.
+    default:
+        The value to return when ``key`` is not present.
+    """
+
+    _load_environment()
+    return os.environ.get(key, default)
+
+
+__all__ = ["get_env"]
+

--- a/virtuallab/exec/adapters/engineer.py
+++ b/virtuallab/exec/adapters/engineer.py
@@ -1,9 +1,10 @@
 """Adapter for the Engineer autonomous agent."""
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Iterable, Protocol
+
+from ...config import get_env
 
 
 def _load_smolagents_dependencies() -> dict[str, Any]:
@@ -58,9 +59,9 @@ class SmolagentsEngineerClient:
     def _create_default_model(self) -> Any:
         """Instantiate :class:`OpenAIServerModel` using environment variables."""
 
-        model_id = os.environ.get("LLM_MODEL")
-        api_base = os.environ.get("LLM_MODEL_URL")
-        api_key = os.environ.get("LLM_MODEL_API_KEY")
+        model_id = get_env("LLM_MODEL")
+        api_base = get_env("LLM_MODEL_URL")
+        api_key = get_env("LLM_MODEL_API_KEY")
         if not model_id or not api_base or not api_key:
             raise EnvironmentError(
                 "LLM_MODEL, LLM_MODEL_URL, and LLM_MODEL_API_KEY environment variables "


### PR DESCRIPTION
## Summary
- add a shared configuration helper that loads environment variables from a project-level .env file
- update the Engineer and OpenAI adapters to read settings through the helper
- declare python-dotenv as a runtime dependency
- provide a repository-level .env template with placeholders for all configuration keys

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da3e0141bc8331b2bd4f4817a9b7c7