### PR TITLE
Add module-specific tests for VirtualLab core components

### DIFF
--- a/dotenv/__init__.py
+++ b/dotenv/__init__.py
@@ -1,0 +1,7 @@
+"""Test stub for :mod:`python-dotenv`."""
+
+from __future__ import annotations
+
+
+def load_dotenv(*args, **kwargs):  # pragma: no cover - simple stub
+    return False

--- a/tests/exec/test_engineer_adapter_module.py
+++ b/tests/exec/test_engineer_adapter_module.py
@@ -1,0 +1,102 @@
+"""Tests for the Engineer adapter wiring."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import builtins
+import importlib
+import pathlib
+import sys
+import types
+
+import pytest
+
+import virtuallab.exec as exec_pkg
+
+ADAPTERS_PACKAGE = "virtuallab.exec.adapters"
+
+
+def load_engineer_module():
+    adapters_path = pathlib.Path(exec_pkg.__file__).resolve().parent / "adapters"
+    sys.modules.pop(ADAPTERS_PACKAGE, None)
+    package = types.ModuleType(ADAPTERS_PACKAGE)
+    package.__path__ = [str(adapters_path)]  # type: ignore[attr-defined]
+    sys.modules[ADAPTERS_PACKAGE] = package
+    return importlib.import_module("virtuallab.exec.adapters.engineer")
+
+
+engineer = load_engineer_module()
+
+
+def test_load_smolagents_dependencies_provides_clear_error(monkeypatch):
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("smolagents"):
+            raise ModuleNotFoundError("smolagents missing")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ModuleNotFoundError) as exc:
+        engineer._load_smolagents_dependencies()
+
+    assert "smolagents" in str(exc.value)
+
+
+def make_stub_dependencies():
+    class StubAgent:
+        def __init__(self, *, tools, model, stream_outputs):
+            self.tools = tools
+            self.model = model
+            self.stream_outputs = stream_outputs
+
+        def run(self, prompt: str) -> str:
+            return f"ran:{prompt}:{len(self.tools)}"
+
+    class StubModel:
+        def __init__(self, *, model_id, api_base, api_key):
+            self.config = (model_id, api_base, api_key)
+
+    return {
+        "CodeAgent": StubAgent,
+        "OpenAIServerModel": StubModel,
+        "WebSearchTool": lambda: "search",
+        "PythonInterpreterTool": lambda: "python",
+    }
+
+
+def test_engineer_client_resolves_tools_and_runs(monkeypatch):
+    monkeypatch.setattr(engineer, "_load_smolagents_dependencies", make_stub_dependencies)
+    monkeypatch.setenv("LLM_MODEL", "model")
+    monkeypatch.setenv("LLM_MODEL_URL", "http://example")
+    monkeypatch.setenv("LLM_MODEL_API_KEY", "key")
+
+    client = engineer.SmolagentsEngineerClient(stream_outputs=True)
+
+    output = client.run("do work", tools=["python", "web_search"])
+    assert output == "ran:do work:2"
+
+
+def test_engineer_client_rejects_unknown_tool(monkeypatch):
+    monkeypatch.setattr(engineer, "_load_smolagents_dependencies", make_stub_dependencies)
+    monkeypatch.setenv("LLM_MODEL", "model")
+    monkeypatch.setenv("LLM_MODEL_URL", "http://example")
+    monkeypatch.setenv("LLM_MODEL_API_KEY", "key")
+
+    client = engineer.SmolagentsEngineerClient()
+
+    with pytest.raises(KeyError):
+        client.run("prompt", tools=["nonexistent"])
+
+
+def test_engineer_adapter_returns_structured_response(monkeypatch):
+    stub_client = mock.Mock()
+    stub_client.run.return_value = "result"
+
+    adapter = engineer.EngineerAdapter(client=stub_client)
+    response = adapter.run(step_id="s", payload={"text": "prompt", "tools": ["python"]})
+
+    assert response == {"step_id": "s", "output": "result"}
+    stub_client.run.assert_called_once_with("prompt", tools=["python"])

--- a/tests/exec/test_runner_and_local_adapter.py
+++ b/tests/exec/test_runner_and_local_adapter.py
@@ -1,0 +1,75 @@
+"""Tests for execution runners and adapters."""
+
+from __future__ import annotations
+
+import importlib
+import pathlib
+import sys
+import types
+
+import pytest
+
+from virtuallab.exec.runner import StepRunner
+import virtuallab.exec as exec_pkg
+
+
+def load_local_module():
+    adapters_path = pathlib.Path(exec_pkg.__file__).resolve().parent / "adapters"
+    package_name = "virtuallab.exec.adapters"
+    sys.modules.pop(package_name, None)
+    package = types.ModuleType(package_name)
+    package.__path__ = [str(adapters_path)]  # type: ignore[attr-defined]
+    sys.modules[package_name] = package
+    return importlib.import_module("virtuallab.exec.adapters.local")
+
+
+local_adapter_module = load_local_module()
+
+
+def test_step_runner_dispatches_registered_adapter():
+    class EchoAdapter:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, dict]] = []
+
+        def run(self, *, step_id: str, payload: dict) -> dict:
+            self.calls.append((step_id, payload))
+            return {"step_id": step_id, "payload": payload}
+
+    runner = StepRunner()
+    adapter = EchoAdapter()
+    runner.register_adapter("echo", adapter)
+
+    result = runner.run(tool="echo", step_id="s1", payload={"value": 1})
+
+    assert result == {"step_id": "s1", "payload": {"value": 1}}
+    assert adapter.calls == [("s1", {"value": 1})]
+
+
+def test_step_runner_missing_adapter():
+    runner = StepRunner()
+    with pytest.raises(KeyError):
+        runner.run(tool="unknown", step_id="s", payload={})
+
+
+def test_local_func_adapter_executes_registered_callable():
+    adapter = local_adapter_module.LocalFuncAdapter()
+
+    def process(payload: dict) -> dict:
+        return {"step_id": payload["step_id"], "double": payload["value"] * 2}
+
+    adapter.register("double", process)
+
+    result = adapter.run(step_id="local-1", payload={"function": "double", "step_id": "local-1", "value": 3})
+    assert result == {"step_id": "local-1", "double": 6}
+
+
+def test_local_func_adapter_missing_function_metadata():
+    adapter = local_adapter_module.LocalFuncAdapter()
+    with pytest.raises(KeyError):
+        adapter.run(step_id="local", payload={})
+
+
+def test_local_func_adapter_missing_registration():
+    adapter = local_adapter_module.LocalFuncAdapter()
+    with pytest.raises(KeyError):
+        adapter.run(step_id="local", payload={"function": "nope"})

--- a/tests/graph/test_ids_module.py
+++ b/tests/graph/test_ids_module.py
@@ -1,0 +1,16 @@
+"""Tests for :mod:`virtuallab.graph.ids`."""
+
+from __future__ import annotations
+
+from virtuallab.graph import ids
+
+
+def test_new_id_prefix_and_uniqueness():
+    identifier = ids.new_id("plan")
+    assert identifier.startswith("plan_")
+    assert identifier != ids.new_id("plan")
+
+
+def test_utc_now_returns_iso_format():
+    timestamp = ids.utc_now()
+    assert "T" in timestamp and timestamp.endswith("Z") is False

--- a/tests/graph/test_model_module.py
+++ b/tests/graph/test_model_module.py
@@ -1,0 +1,58 @@
+"""Tests covering :mod:`virtuallab.graph.model`."""
+
+from __future__ import annotations
+
+import pytest
+
+from virtuallab.graph.model import (
+    EdgeSpec,
+    EdgeType,
+    GraphDelta,
+    GraphSchema,
+    NodeSpec,
+    NodeType,
+    coerce_edge_payload,
+    coerce_node_payload,
+)
+
+
+def test_node_spec_update_merges_values():
+    node = NodeSpec(id="n1", type=NodeType.PLAN, attributes={"name": "plan"})
+    node.update({"status": "active"})
+    assert node.attributes == {"name": "plan", "status": "active"}
+
+
+def test_graph_schema_required_fields():
+    fields = tuple(GraphSchema.required_fields_for(NodeType.PLAN))
+    assert {"name", "goal", "owner", "status"}.issubset(fields)
+
+
+def test_graph_schema_edge_fields_default():
+    fields = tuple(GraphSchema.edge_fields_for(EdgeType.USES_DATA))
+    assert fields == ("role",)
+
+
+def test_coerce_node_payload_validates_identifier():
+    with pytest.raises(ValueError):
+        coerce_node_payload(NodeType.PLAN, attributes={"name": "p", "goal": "g", "owner": "o", "status": "draft"})
+
+
+def test_coerce_node_payload_generates_spec_with_defaults():
+    node = coerce_node_payload(
+        NodeType.PLAN,
+        attributes={"id": "plan_1", "name": "p", "goal": "g", "owner": "o", "status": "draft"},
+    )
+    assert node.id == "plan_1"
+    assert node.attributes["labels"] == []
+
+
+def test_coerce_edge_payload_populates_default_fields():
+    edge = coerce_edge_payload(EdgeType.ASSOCIATED_WITH, source="a", target="b", attributes={"score": 0.5})
+    assert isinstance(edge, EdgeSpec)
+    assert edge.attributes["score"] == 0.5
+
+
+def test_graph_delta_defaults_iterables():
+    delta = GraphDelta()
+    assert list(delta.added_nodes) == []
+    assert list(delta.added_edges) == []

--- a/tests/graph/test_query_module.py
+++ b/tests/graph/test_query_module.py
@@ -1,0 +1,66 @@
+"""Tests for :mod:`virtuallab.graph.query`."""
+
+from __future__ import annotations
+
+import itertools
+
+import networkx as nx
+
+from virtuallab.graph.query import QueryService
+
+
+def build_graph():
+    graph = nx.MultiDiGraph()
+    graph.add_node("plan_1", type="Plan", created_at="2024-01-01T00:00:00")
+    graph.add_node("subtask_1", type="Subtask", plan_id="plan_1", created_at="2024-01-02T00:00:00")
+    graph.add_node(
+        "step_1",
+        type="Step",
+        subtask_id="subtask_1",
+        executed_at="2024-01-03T00:00:00",
+        tool="python",
+    )
+    graph.add_node("note_1", type="Note", created_at="2024-01-04T00:00:00")
+    graph.add_edge("plan_1", "subtask_1", key="CONTAINS", type="CONTAINS")
+    graph.add_edge("subtask_1", "step_1", key="CONTAINS", type="CONTAINS")
+    graph.add_edge("note_1", "step_1", key="ASSOCIATED_WITH", type="ASSOCIATED_WITH")
+    return graph
+
+
+def test_by_type_filters_results():
+    service = QueryService(build_graph())
+    results = list(service.by_type("Step", tool="python"))
+    assert results and results[0]["id"] == "step_1"
+
+
+def test_neighbors_respects_hop_and_edge_types():
+    service = QueryService(build_graph())
+    results = list(service.neighbors("plan_1", hop=2, edge_types=["CONTAINS"]))
+    ids = {item["id"] for item in results}
+    assert ids == {"subtask_1", "step_1"}
+
+
+def test_neighbors_missing_node_yields_empty_iterator():
+    service = QueryService(build_graph())
+    assert list(service.neighbors("missing")) == []
+
+
+def test_timeline_orders_by_timestamp():
+    service = QueryService(build_graph())
+    items = list(service.timeline(include=["Plan", "Step", "Note"]))
+    ids_in_order = [item["id"] for item in items]
+    assert ids_in_order == ["plan_1", "step_1", "note_1"]
+
+
+def test_timeline_scoped_to_plan_members():
+    graph = build_graph()
+    graph.add_node("step_2", type="Step", subtask_id="subtask_2", executed_at="2024-01-05T00:00:00")
+    service = QueryService(graph)
+    scoped = list(service.timeline(scope={"plan_id": "plan_1"}))
+    assert all(item["id"] != "step_2" for item in scoped)
+
+
+def test_collect_plan_members_includes_subtasks_and_steps():
+    service = QueryService(build_graph())
+    members = service._collect_plan_members("plan_1")
+    assert {"plan_1", "subtask_1", "step_1"}.issubset(members)

--- a/tests/graph/test_rules_module.py
+++ b/tests/graph/test_rules_module.py
@@ -1,0 +1,110 @@
+"""Tests for :mod:`virtuallab.graph.rules`."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+import networkx as nx
+
+from virtuallab.graph.model import EdgeType, GraphDelta, NodeSpec, NodeType
+from virtuallab.graph.rules import (
+    AutoLinkCandidate,
+    AutoLinkContext,
+    AutoLinkProposal,
+    AutoLinkResult,
+    AutoLinkService,
+    DEFAULT_RULES,
+    RuleDescription,
+)
+
+
+class StubAdapter:
+    """Adapter returning a predefined proposal for inspection."""
+
+    def __init__(self, proposal: AutoLinkProposal) -> None:
+        self.proposal = proposal
+        self.seen_contexts: list[AutoLinkContext] = []
+
+    def propose_links(self, *, context: AutoLinkContext) -> AutoLinkProposal:
+        self.seen_contexts.append(context)
+        return self.proposal
+
+
+def build_store():
+    from virtuallab.graph.store import GraphStore
+
+    store = GraphStore()
+    plan = NodeSpec(id="plan_1", type=NodeType.PLAN, attributes={"name": "Plan"})
+    data = NodeSpec(id="data_1", type=NodeType.DATA, attributes={"payload_ref": "ref", "format": "json", "source": "lab"})
+    store.add_node(plan)
+    store.add_node(data)
+    return store
+
+
+def test_autolink_context_payload_shape():
+    context = AutoLinkContext(scope={"plan": "plan_1"}, nodes=[{"id": "n"}], edges=[], rules=list(DEFAULT_RULES.values()))
+    payload = context.to_prompt_payload()
+    assert payload["scope"] == {"plan": "plan_1"}
+    assert payload["nodes"] == [{"id": "n"}]
+
+
+def test_candidate_payload_includes_optional_fields():
+    candidate = AutoLinkCandidate(
+        source="plan_1",
+        target="data_1",
+        type=EdgeType.USES_DATA,
+        rationale="needs data",
+        confidence=0.8,
+        attributes={"role": "input"},
+    )
+    payload = candidate.to_payload()
+    assert payload["rationale"] == "needs data"
+    assert payload["attributes"]["role"] == "input"
+
+
+def test_autolink_service_filters_missing_and_duplicate_edges():
+    store = build_store()
+    store.graph.add_edge("plan_1", "data_1", key="USES_DATA", type="USES_DATA")
+
+    proposal = AutoLinkProposal(
+        candidates=[
+            AutoLinkCandidate(source="plan_1", target="data_1", type=EdgeType.USES_DATA),
+            AutoLinkCandidate(source="plan_1", target="unknown", type=EdgeType.USES_DATA),
+            AutoLinkCandidate(
+                source="data_1",
+                target="plan_1",
+                type=EdgeType.DEPENDS_ON,
+                rationale="reverse",
+                confidence=0.9,
+            ),
+        ],
+        analysis="analysis",
+    )
+    adapter = StubAdapter(proposal)
+    service = AutoLinkService(adapter=adapter)
+
+    result = service.generate(graph_store=store, scope=None, rules=["dependency", "Temporal", "logic"])
+
+    # Only the third candidate should be applied because the first is duplicate and second missing target.
+    assert [edge.type for edge in result.delta.added_edges] == [EdgeType.DEPENDS_ON]
+    assert len(result.applied) == 1
+    assert result.skipped and {item["reason"] for item in result.skipped} == {"duplicate", "missing-node"}
+
+    # Ensure rules were normalised and context captured.
+    assert {rule.name for rule in result.context.rules} == {"dependency", "temporal"}
+    assert adapter.seen_contexts and adapter.seen_contexts[0].nodes
+
+
+def test_autolink_result_payload_serialisable():
+    context = AutoLinkContext(scope=None, nodes=[], edges=[], rules=())
+    result = AutoLinkResult(
+        context=context,
+        applied=[AutoLinkCandidate(source="a", target="b", type=EdgeType.ASSOCIATED_WITH)],
+        skipped=[{"candidate": {"source": "x"}, "reason": "duplicate"}],
+        delta=GraphDelta(),
+        analysis="analysis",
+    )
+    payload = result.to_payload()
+    assert payload["applied"][0]["source"] == "a"
+    assert payload["analysis"] == "analysis"

--- a/tests/graph/test_store_module.py
+++ b/tests/graph/test_store_module.py
@@ -1,0 +1,43 @@
+"""Tests for :mod:`virtuallab.graph.store`."""
+
+from __future__ import annotations
+
+from virtuallab.graph.model import EdgeSpec, EdgeType, GraphDelta, NodeSpec, NodeType
+from virtuallab.graph.store import GraphStore
+
+
+def make_plan_node(identifier: str) -> NodeSpec:
+    return NodeSpec(id=identifier, type=NodeType.PLAN, attributes={"name": identifier})
+
+
+def test_graph_store_adds_nodes_and_edges():
+    store = GraphStore()
+    node_a = make_plan_node("plan_a")
+    node_b = make_plan_node("plan_b")
+    edge = EdgeSpec(source=node_a.id, target=node_b.id, type=EdgeType.ASSOCIATED_WITH)
+
+    store.add_node(node_a)
+    store.add_node(node_b)
+    store.add_edge(edge)
+
+    retrieved = store.get_node("plan_a")
+    assert retrieved is not None
+    assert retrieved.id == "plan_a"
+    assert retrieved.attributes["name"] == "plan_a"
+
+    edges = list(store.edges())
+    assert edges[0][0] == node_a.id and edges[0][1] == node_b.id
+
+
+def test_graph_store_apply_delta_updates_nodes():
+    store = GraphStore()
+    original = make_plan_node("plan_a")
+    store.add_node(original)
+
+    updated = NodeSpec(id="plan_a", type=NodeType.PLAN, attributes={"status": "active"})
+    delta = GraphDelta(updated_nodes=[updated])
+    store.apply_delta(delta)
+
+    node = store.get_node("plan_a")
+    assert node is not None
+    assert node.attributes["status"] == "active"

--- a/tests/knowledge/test_summarize_module.py
+++ b/tests/knowledge/test_summarize_module.py
@@ -1,0 +1,52 @@
+"""Tests for :mod:`virtuallab.knowledge.summarize`."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from virtuallab.knowledge.summarize import (
+    OpenAILLMSummarizerAdapter,
+    SummaryService,
+    _ensure_text,
+)
+
+
+async def async_text_generator(chunks: list[str]):
+    for chunk in chunks:
+        await asyncio.sleep(0)
+        yield chunk
+
+
+def test_ensure_text_handles_async_iterator():
+    async def run():
+        return await _ensure_text(async_text_generator(["a", "b", "c"]))
+
+    result = asyncio.run(run())
+    assert result == "abc"
+
+
+def test_openai_llm_summarizer_builds_prompt_and_invokes_completion(monkeypatch):
+    calls: list[dict[str, object]] = []
+
+    async def completion(prompt: str, **kwargs):
+        calls.append({"prompt": prompt, **kwargs})
+        return "summary"
+
+    adapter = OpenAILLMSummarizerAdapter(completion_func=completion)
+    summary = adapter.summarize(text="Important findings", style="bullet")
+
+    assert "Important findings" in calls[0]["prompt"]
+    assert "bullet" in calls[0]["prompt"]
+    assert summary == "summary"
+
+
+def test_summary_service_wraps_adapter():
+    class StubAdapter:
+        def summarize(self, *, text: str, style: str | None = None) -> str:
+            return f"processed:{text}:{style}"
+
+    service = SummaryService(adapter=StubAdapter())
+    payload = service.summarize(text="content", style=None)
+    assert payload == {"summary": "processed:content:None", "style": None}

--- a/tests/obs/test_events_module.py
+++ b/tests/obs/test_events_module.py
@@ -1,0 +1,14 @@
+"""Tests for :mod:`virtuallab.obs.events`."""
+
+from __future__ import annotations
+
+from virtuallab.obs.events import EventBus
+
+
+def test_event_bus_emit_and_history(monkeypatch):
+    bus = EventBus()
+    event = bus.emit(level="info", msg="Test", action="act", target_ids=["node"], extras={"detail": 1})
+
+    assert event.msg == "Test"
+    history = list(bus.history())
+    assert history == [event]

--- a/tests/persist/test_snapshot_and_export_module.py
+++ b/tests/persist/test_snapshot_and_export_module.py
@@ -1,0 +1,28 @@
+"""Tests for persistence helpers."""
+
+from __future__ import annotations
+
+import networkx as nx
+import pytest
+
+from virtuallab.persist.snapshot import SnapshotManager
+from virtuallab.persist.export import GraphExporter
+
+
+def test_snapshot_manager_roundtrip():
+    manager = SnapshotManager()
+    graph = nx.MultiDiGraph()
+    graph.add_node("n1", type="Plan")
+    manager.snapshot(graph)
+
+    restored = manager.rollback()
+    assert list(restored.nodes) == ["n1"]
+
+    with pytest.raises(RuntimeError):
+        manager.rollback()
+
+
+def test_graph_exporter_rejects_unknown_format():
+    exporter = GraphExporter(graph=nx.MultiDiGraph())
+    with pytest.raises(ValueError):
+        exporter.export(format="unsupported")

--- a/tests/test_config_module.py
+++ b/tests/test_config_module.py
@@ -1,0 +1,26 @@
+"""Tests for :mod:`virtuallab.config`."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+from virtuallab import config
+
+
+def test_get_env_returns_default_when_missing(monkeypatch):
+    config._load_environment.cache_clear()  # reset cache to isolate tests
+    monkeypatch.delenv("VIRTUALLAB_FAKE", raising=False)
+    assert config.get_env("VIRTUALLAB_FAKE", default="fallback") == "fallback"
+
+
+def test_get_env_ensures_environment_loaded(monkeypatch):
+    config._load_environment.cache_clear()
+    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    with mock.patch.object(config, "load_dotenv", autospec=True) as load_mock:
+        load_mock.side_effect = lambda *args, **kwargs: calls.append((args, kwargs))
+        monkeypatch.setenv("VIRTUALLAB_ENV_FLAG", "42")
+        assert config.get_env("VIRTUALLAB_ENV_FLAG") == "42"
+
+    # ``load_dotenv`` should have been invoked exactly once through the cached loader.
+    assert len(calls) == 1

--- a/tests/test_router_module.py
+++ b/tests/test_router_module.py
@@ -1,0 +1,23 @@
+"""Tests for :mod:`virtuallab.router`."""
+
+from __future__ import annotations
+
+import pytest
+
+from virtuallab.router import ActionRouter
+
+
+def test_router_dispatches_registered_handler():
+    router = ActionRouter()
+
+    def handler(params: dict) -> dict:
+        return {"result": params["value"] * 2}
+
+    router.register("double", handler)
+    assert router.dispatch("double", {"value": 21}) == {"result": 42}
+
+
+def test_router_dispatch_missing_action():
+    router = ActionRouter()
+    with pytest.raises(KeyError):
+        router.dispatch("unknown", {})


### PR DESCRIPTION
## Summary
- add a lightweight `dotenv` stub so the configuration helper can be imported without external dependencies during testing
- introduce focused pytest modules that exercise the execution adapters, graph utilities, and supporting services
- cover configuration, routing, persistence, knowledge, and observation helpers with direct unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da434198848331a203f97b24f948fb