### PR TITLE
test: validate autolink service against real adapter

### DIFF
--- a/tests/graph/test_rules_module.py
+++ b/tests/graph/test_rules_module.py
@@ -2,51 +2,55 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Iterable, Sequence
-
-import networkx as nx
+import json
 
 from virtuallab.graph.model import EdgeType, GraphDelta, NodeSpec, NodeType
 from virtuallab.graph.rules import (
     AutoLinkCandidate,
     AutoLinkContext,
-    AutoLinkProposal,
     AutoLinkResult,
     AutoLinkService,
-    DEFAULT_RULES,
-    RuleDescription,
+    OpenAIAutoLinkAdapter,
 )
+from virtuallab.graph.store import GraphStore
 
 
-class StubAdapter:
-    """Adapter returning a predefined proposal for inspection."""
-
-    def __init__(self, proposal: AutoLinkProposal) -> None:
-        self.proposal = proposal
-        self.seen_contexts: list[AutoLinkContext] = []
-
-    def propose_links(self, *, context: AutoLinkContext) -> AutoLinkProposal:
-        self.seen_contexts.append(context)
-        return self.proposal
-
-
-def build_store():
-    from virtuallab.graph.store import GraphStore
-
+def build_store() -> GraphStore:
     store = GraphStore()
     plan = NodeSpec(id="plan_1", type=NodeType.PLAN, attributes={"name": "Plan"})
-    data = NodeSpec(id="data_1", type=NodeType.DATA, attributes={"payload_ref": "ref", "format": "json", "source": "lab"})
+    data = NodeSpec(
+        id="data_1",
+        type=NodeType.DATA,
+        attributes={"payload_ref": "ref", "format": "json", "source": "lab"},
+    )
     store.add_node(plan)
     store.add_node(data)
     return store
 
 
-def test_autolink_context_payload_shape():
-    context = AutoLinkContext(scope={"plan": "plan_1"}, nodes=[{"id": "n"}], edges=[], rules=list(DEFAULT_RULES.values()))
-    payload = context.to_prompt_payload()
-    assert payload["scope"] == {"plan": "plan_1"}
-    assert payload["nodes"] == [{"id": "n"}]
+def test_autolink_service_builds_context_from_store():
+    store = build_store()
+    store.graph.add_edge("plan_1", "data_1", key="USES_DATA", type="USES_DATA")
+
+    captured_payload: dict | None = None
+
+    async def fake_completion(prompt: str, **kwargs):
+        nonlocal captured_payload
+        _, payload_text = prompt.split("Graph context:\n", 1)
+        captured_payload = json.loads(payload_text)
+        return json.dumps({"links": []})
+
+    adapter = OpenAIAutoLinkAdapter(completion_func=fake_completion)
+    service = AutoLinkService(adapter=adapter)
+
+    result = service.generate(graph_store=store, scope={"plan": "plan_1"}, rules=["temporal"])
+
+    assert result.context.scope == {"plan": "plan_1"}
+    assert {node["id"] for node in result.context.nodes} == {"plan_1", "data_1"}
+    assert any(edge["type"] == "USES_DATA" for edge in result.context.edges)
+    assert {rule.name for rule in result.context.rules} == {"temporal"}
+    assert captured_payload is not None
+    assert {node["id"] for node in captured_payload["nodes"]} == {"plan_1", "data_1"}
 
 
 def test_candidate_payload_includes_optional_fields():
@@ -67,33 +71,34 @@ def test_autolink_service_filters_missing_and_duplicate_edges():
     store = build_store()
     store.graph.add_edge("plan_1", "data_1", key="USES_DATA", type="USES_DATA")
 
-    proposal = AutoLinkProposal(
-        candidates=[
-            AutoLinkCandidate(source="plan_1", target="data_1", type=EdgeType.USES_DATA),
-            AutoLinkCandidate(source="plan_1", target="unknown", type=EdgeType.USES_DATA),
-            AutoLinkCandidate(
-                source="data_1",
-                target="plan_1",
-                type=EdgeType.DEPENDS_ON,
-                rationale="reverse",
-                confidence=0.9,
-            ),
-        ],
-        analysis="analysis",
-    )
-    adapter = StubAdapter(proposal)
+    async def fake_completion(prompt: str, **kwargs):
+        response = {
+            "links": [
+                {"source": "plan_1", "target": "data_1", "type": "USES_DATA"},
+                {"source": "plan_1", "target": "unknown", "type": "USES_DATA"},
+                {
+                    "source": "data_1",
+                    "target": "plan_1",
+                    "type": "DEPENDS_ON",
+                    "rationale": "reverse",
+                    "confidence": 0.9,
+                },
+            ],
+            "analysis": "analysis",
+        }
+        return json.dumps(response)
+
+    adapter = OpenAIAutoLinkAdapter(completion_func=fake_completion)
     service = AutoLinkService(adapter=adapter)
 
     result = service.generate(graph_store=store, scope=None, rules=["dependency", "Temporal", "logic"])
 
-    # Only the third candidate should be applied because the first is duplicate and second missing target.
     assert [edge.type for edge in result.delta.added_edges] == [EdgeType.DEPENDS_ON]
+    assert [edge.attributes["rationale"] for edge in result.delta.added_edges] == ["reverse"]
     assert len(result.applied) == 1
+    assert result.analysis == "analysis"
     assert result.skipped and {item["reason"] for item in result.skipped} == {"duplicate", "missing-node"}
-
-    # Ensure rules were normalised and context captured.
     assert {rule.name for rule in result.context.rules} == {"dependency", "temporal"}
-    assert adapter.seen_contexts and adapter.seen_contexts[0].nodes
 
 
 def test_autolink_result_payload_serialisable():


### PR DESCRIPTION
## Summary
- replace stubbed auto-link adapter tests with OpenAIAutoLinkAdapter based coverage
- assert generated contexts, filtering, and prompts using the real GraphStore and adapter logic

## Testing
- pytest tests/graph -q

------
https://chatgpt.com/codex/tasks/task_e_68db3e474a448331b14552347a9fd9b5