### PR TITLE
Improve runner and local adapter tests

### DIFF
--- a/tests/exec/test_runner_and_local_adapter.py
+++ b/tests/exec/test_runner_and_local_adapter.py
@@ -9,8 +9,9 @@ import types
 
 import pytest
 
-from virtuallab.exec.runner import StepRunner
+import virtuallab.api as api_module
 import virtuallab.exec as exec_pkg
+from virtuallab.exec.runner import StepRunner
 
 
 def load_local_module():
@@ -26,23 +27,75 @@ def load_local_module():
 local_adapter_module = load_local_module()
 
 
-def test_step_runner_dispatches_registered_adapter():
-    class EchoAdapter:
-        def __init__(self) -> None:
-            self.calls: list[tuple[str, dict]] = []
+def test_step_runner_runs_virtual_lab_step_via_local_adapter(monkeypatch):
+    app = api_module.VirtualLabApp()
+    monkeypatch.setattr(api_module, "_APP", app)
 
-        def run(self, *, step_id: str, payload: dict) -> dict:
-            self.calls.append((step_id, payload))
-            return {"step_id": step_id, "payload": payload}
+    local_adapter = local_adapter_module.LocalFuncAdapter()
+    app.step_runner.register_adapter("local", local_adapter)
 
-    runner = StepRunner()
-    adapter = EchoAdapter()
-    runner.register_adapter("echo", adapter)
+    def complete_step(payload: dict) -> dict:
+        step_id = payload["step_id"]
+        inputs = payload.get("inputs", {})
+        total = sum(value for value in inputs.values() if isinstance(value, (int, float)))
+        return {
+            "step_id": step_id,
+            "status": "completed",
+            "output": {"sum": total, "inputs": inputs},
+            "metrics": {"input_count": len(inputs)},
+        }
 
-    result = runner.run(tool="echo", step_id="s1", payload={"value": 1})
+    local_adapter.register("complete_step", complete_step)
 
-    assert result == {"step_id": "s1", "payload": {"value": 1}}
-    assert adapter.calls == [("s1", {"value": 1})]
+    plan_response = api_module.VirtualLab_tool({
+        "action": "create_plan",
+        "params": {"name": "Integration plan"},
+    })
+    plan_id = plan_response["result"]["plan_id"]
+
+    subtask_response = api_module.VirtualLab_tool({
+        "action": "add_subtask",
+        "params": {"plan_id": plan_id, "name": "Integration task"},
+    })
+    subtask_id = subtask_response["result"]["subtask_id"]
+
+    step_response = api_module.VirtualLab_tool({
+        "action": "add_step",
+        "params": {
+            "subtask_id": subtask_id,
+            "name": "Compute sum",
+            "tool": "local",
+        },
+    })
+    step_id = step_response["result"]["step_id"]
+
+    run_response = api_module.VirtualLab_tool({
+        "action": "run_step",
+        "params": {
+            "step_id": step_id,
+            "tool": "local",
+            "payload": {
+                "function": "complete_step",
+                "step_id": step_id,
+                "inputs": {"a": 1, "b": 2},
+            },
+        },
+    })
+
+    assert run_response["result"]["status"] == "completed"
+    assert run_response["result"]["output"] == {
+        "sum": 3,
+        "inputs": {"a": 1, "b": 2},
+    }
+    assert run_response["result"]["details"]["metrics"] == {"input_count": 2}
+
+    step_node = app.graph_store.get_node(step_id)
+    assert step_node is not None
+    assert step_node.attributes["status"] == "completed"
+    assert step_node.attributes["last_run_output"] == {
+        "sum": 3,
+        "inputs": {"a": 1, "b": 2},
+    }
 
 
 def test_step_runner_missing_adapter():
@@ -51,16 +104,25 @@ def test_step_runner_missing_adapter():
         runner.run(tool="unknown", step_id="s", payload={})
 
 
-def test_local_func_adapter_executes_registered_callable():
+def test_local_func_adapter_runs_virtual_lab_tool(monkeypatch):
+    app = api_module.VirtualLabApp()
+    monkeypatch.setattr(api_module, "_APP", app)
+
     adapter = local_adapter_module.LocalFuncAdapter()
+    adapter.register("VirtualLab_tool", api_module.VirtualLab_tool)
 
-    def process(payload: dict) -> dict:
-        return {"step_id": payload["step_id"], "double": payload["value"] * 2}
+    response = adapter.run(
+        step_id="local-1",
+        payload={
+            "function": "VirtualLab_tool",
+            "action": "create_plan",
+            "params": {"name": "Direct call"},
+        },
+    )
 
-    adapter.register("double", process)
-
-    result = adapter.run(step_id="local-1", payload={"function": "double", "step_id": "local-1", "value": 3})
-    assert result == {"step_id": "local-1", "double": 6}
+    assert response["ok"] is True
+    plan_id = response["result"]["plan_id"]
+    assert app.graph_store.get_node(plan_id) is not None
 
 
 def test_local_func_adapter_missing_function_metadata():


### PR DESCRIPTION
## Summary
- exercise the step runner against VirtualLab_app via the real local function adapter
- cover the local adapter invoking VirtualLab_tool while retaining error handling cases

## Testing
- pytest tests/exec/test_runner_and_local_adapter.py

------
https://chatgpt.com/codex/tasks/task_e_68db3e2a6fbc8331b92550ff9ca04d91