### PR TITLE
Improve knowledge summarizer tests

### DIFF
--- a/tests/knowledge/test_summarize_module.py
+++ b/tests/knowledge/test_summarize_module.py
@@ -27,26 +27,37 @@ def test_ensure_text_handles_async_iterator():
     assert result == "abc"
 
 
-def test_openai_llm_summarizer_builds_prompt_and_invokes_completion(monkeypatch):
+@pytest.fixture()
+def recorded_completion(monkeypatch):
     calls: list[dict[str, object]] = []
 
-    async def completion(prompt: str, **kwargs):
-        calls.append({"prompt": prompt, **kwargs})
+    async def completion(prompt: str, *, system_prompt: str, **kwargs):
+        calls.append({"prompt": prompt, "system_prompt": system_prompt, "kwargs": kwargs})
         return "summary"
 
-    adapter = OpenAILLMSummarizerAdapter(completion_func=completion)
+    monkeypatch.setattr(
+        "virtuallab.exec.adapters.openai_model.gpt_4o_mini_complete", completion
+    )
+    return calls
+
+
+def test_openai_llm_summarizer_builds_prompt_and_invokes_completion(recorded_completion):
+    adapter = OpenAILLMSummarizerAdapter()
+
     summary = adapter.summarize(text="Important findings", style="bullet")
 
-    assert "Important findings" in calls[0]["prompt"]
-    assert "bullet" in calls[0]["prompt"]
     assert summary == "summary"
+    assert len(recorded_completion) == 1
+    prompt = recorded_completion[0]["prompt"]
+    assert "Important findings" in prompt
+    assert "bullet" in prompt
+    assert recorded_completion[0]["system_prompt"].startswith("You are an expert")
 
 
-def test_summary_service_wraps_adapter():
-    class StubAdapter:
-        def summarize(self, *, text: str, style: str | None = None) -> str:
-            return f"processed:{text}:{style}"
+def test_summary_service_wraps_adapter(recorded_completion):
+    adapter = OpenAILLMSummarizerAdapter()
+    service = SummaryService(adapter=adapter)
 
-    service = SummaryService(adapter=StubAdapter())
-    payload = service.summarize(text="content", style=None)
-    assert payload == {"summary": "processed:content:None", "style": None}
+    payload = service.summarize(text="content", style="concise")
+
+    assert payload == {"summary": "summary", "style": "concise"}


### PR DESCRIPTION
## Summary
- update knowledge summarizer tests to exercise the real OpenAILLMSummarizerAdapter wiring
- verify SummaryService integrates with the adapter while capturing real prompt information

## Testing
- pytest tests/knowledge/test_summarize_module.py

------
https://chatgpt.com/codex/tasks/task_e_68db3e5f4dc083319b31da81bb2c413f