### PR TITLE
Improve config tests to exercise real environment loading

### DIFF
--- a/tests/test_config_module.py
+++ b/tests/test_config_module.py
@@ -2,25 +2,67 @@
 
 from __future__ import annotations
 
-from unittest import mock
+from pathlib import Path
 
 from virtuallab import config
 
 
-def test_get_env_returns_default_when_missing(monkeypatch):
-    config._load_environment.cache_clear()  # reset cache to isolate tests
-    monkeypatch.delenv("VIRTUALLAB_FAKE", raising=False)
-    assert config.get_env("VIRTUALLAB_FAKE", default="fallback") == "fallback"
+PROJECT_ROOT = Path(config.__file__).resolve().parents[1]
 
 
-def test_get_env_ensures_environment_loaded(monkeypatch):
+def test_get_env_reads_from_project_dotenv(monkeypatch):
+    """The helper should pull values from the real project ``.env`` file."""
+
     config._load_environment.cache_clear()
-    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    monkeypatch.delenv("LLM_MODEL", raising=False)
 
-    with mock.patch.object(config, "load_dotenv", autospec=True) as load_mock:
-        load_mock.side_effect = lambda *args, **kwargs: calls.append((args, kwargs))
-        monkeypatch.setenv("VIRTUALLAB_ENV_FLAG", "42")
-        assert config.get_env("VIRTUALLAB_ENV_FLAG") == "42"
+    value = config.get_env("LLM_MODEL")
 
-    # ``load_dotenv`` should have been invoked exactly once through the cached loader.
-    assert len(calls) == 1
+    # ``LLM_MODEL`` is defined in the repository level ``.env`` file.
+    assert value == "qwen3-max"
+
+
+def test_get_env_prefers_process_environment(monkeypatch):
+    """Explicit environment variables should win over the file contents."""
+
+    config._load_environment.cache_clear()
+    monkeypatch.setenv("LLM_MODEL", "in-memory")
+
+    assert config.get_env("LLM_MODEL") == "in-memory"
+
+
+def test_get_env_can_reload_after_cache_clear(monkeypatch):
+    """Clearing the cache allows the loader to pick up updated ``.env`` values."""
+
+    env_file = PROJECT_ROOT / ".env"
+    original_contents = env_file.read_text()
+    key = "VIRTUALLAB_TEST_TEMP"
+
+    try:
+        # Append a temporary setting and verify it is discovered.
+        env_file.write_text(f"{original_contents}\n{key}=first\n")
+        config._load_environment.cache_clear()
+        monkeypatch.delenv(key, raising=False)
+        assert config.get_env(key) == "first"
+
+        # Update the value and show that cache clearing is required to see it.
+        env_file.write_text(f"{original_contents}\n{key}=second\n")
+        monkeypatch.delenv(key, raising=False)
+        assert config.get_env(key) is None
+
+        config._load_environment.cache_clear()
+        monkeypatch.delenv(key, raising=False)
+        assert config.get_env(key) == "second"
+    finally:
+        env_file.write_text(original_contents)
+        monkeypatch.delenv(key, raising=False)
+        config._load_environment.cache_clear()
+
+
+def test_get_env_returns_default_when_missing(monkeypatch):
+    """Missing keys should fall back to the provided default value."""
+
+    config._load_environment.cache_clear()
+    monkeypatch.delenv("VIRTUALLAB_DOES_NOT_EXIST", raising=False)
+
+    assert config.get_env("VIRTUALLAB_DOES_NOT_EXIST", default="fallback") == "fallback"


### PR DESCRIPTION
## Summary
- update configuration tests to load values from the project .env file instead of mocks
- ensure cache clearing and process environment precedence are validated against the real loader

## Testing
- pytest tests/test_config_module.py

------
https://chatgpt.com/codex/tasks/task_e_68db3e98e09c833197276a8ea6d97799