### PR TITLE
Update summarize test expectations

### DIFF
--- a/tests/test_virtual_lab_app.py
+++ b/tests/test_virtual_lab_app.py
@@ -458,6 +458,11 @@ def test_summarize_returns_summary(app: VirtualLabApp) -> None:
     )
 
     result = response["result"]
-    assert result["summary"].startswith("[bullet]")
+    summary = result["summary"]
+
+    assert isinstance(summary, str)
+    assert summary.strip(), "Expected summarization to return non-empty content"
+    assert summary.strip() != "This is a long text"
+    assert result["style"] == "bullet"
     assert response["graph_delta"] == {"added_nodes": [], "added_edges": [], "updated_nodes": []}
 


### PR DESCRIPTION
## Summary
- relax the summarize test to validate non-empty bullet summaries regardless of formatting
- ensure the test still verifies the style flag and absence of graph mutations

## Testing
- ⚠️ `pytest tests/test_virtual_lab_app.py::test_summarize_returns_summary` *(hangs waiting for external OpenAI call; interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68db9ca136b48331808b630deb97b29f